### PR TITLE
Fix global meetup community members stat from 12,000 to 120,000

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -194,7 +194,7 @@ const featuredArticles = allArticles
     stats={[
       { value: "130,000+", label: "Green Software Practitioner course completions" },
       { value: "12,000", label: "LinkedIn followers" },
-      { value: "12,000", label: "Global meetup community members" },
+      { value: "120,000", label: "Global meetup community members" },
       { value: "450,000", label: "Podcast downloads" },
       { value: "7,800+", label: "Newsletter subscribers" },
     ]}


### PR DESCRIPTION
## Summary
Corrected an inaccurate statistic on the homepage regarding global meetup community members.

## Changes
- Updated the "Global meetup community members" stat value from "12,000" to "120,000" on the homepage

## Details
The previous value of 12,000 was a duplicate of the LinkedIn followers stat and did not reflect the actual number of global meetup community members. This change corrects the statistic to the accurate figure of 120,000.

https://claude.ai/code/session_01CK27YhXoagdjDbGsmocVbq