### PR TITLE
Add Netlify Image CDN optimisation

### DIFF
--- a/src/components/card-grid.astro
+++ b/src/components/card-grid.astro
@@ -1,5 +1,6 @@
 ---
 import { Button } from "@/components/ui/button";
+import Image from "@/components/image.astro";
 
 interface CardItem {
   icon?: string;
@@ -89,13 +90,13 @@ const hasAccentSyntax = headingParts.some(p => p.accent);
         ]}>
           {card.imageSrc && (
             <div class="overflow-hidden">
-              <img src={card.imageSrc} alt={card.title} class="aspect-[3/2] w-full object-cover" />
+              <Image src={card.imageSrc} alt={card.title} class="aspect-[3/2] w-full object-cover" sizes="(min-width: 1024px) 25vw, (min-width: 640px) 50vw, 100vw" />
             </div>
           )}
           <div class="flex flex-col flex-grow p-6">
             {card.icon && !card.imageSrc && (
               <>
-                <img src={card.icon} alt="" class="mb-3 h-8 w-8 shrink-0" />
+                <Image src={card.icon} alt="" class="mb-3 h-8 w-8 shrink-0" sizes="32px" />
                 <hr class:list={["mb-4", card.featured ? "border-white/20" : "border-border"]} />
                 <h3 class:list={["text-lg font-bold", card.featured ? "text-white" : "text-primary"]}>
                   {card.title}
@@ -104,7 +105,7 @@ const hasAccentSyntax = headingParts.some(p => p.accent);
             )}
             {card.icon && card.imageSrc && (
               <div class="mb-2 flex items-center gap-2">
-                <img src={card.icon} alt="" class="h-6 w-6 shrink-0" />
+                <Image src={card.icon} alt="" class="h-6 w-6 shrink-0" sizes="24px" />
                 <h3 class:list={["text-xl font-bold", card.featured ? "text-white" : "text-primary"]}>
                   {card.title}
                 </h3>
@@ -135,7 +136,7 @@ const hasAccentSyntax = headingParts.some(p => p.accent);
       ))}
     </div>
     {decorSrc && (
-      <img class="absolute top-[13px] right-[1.5%] -z-0 hidden px-[5%] lg:block" src={decorSrc} />
+      <Image class="absolute top-[13px] right-[1.5%] -z-0 hidden px-[5%] lg:block" src={decorSrc} alt="" />
     )}
   </div>
 </section>

--- a/src/components/community-reach.astro
+++ b/src/components/community-reach.astro
@@ -1,5 +1,6 @@
 ---
 import { Button } from "@/components/ui/button";
+import Image from "@/components/image.astro";
 
 interface Stat {
   /** Large number/value */
@@ -75,7 +76,7 @@ const headingParts = heading.split(/(\*[^*]+\*)/g).filter(Boolean).map(part => {
     </div>
     {imageSrc && (
       <div class="mt-10">
-        <img src={imageSrc} alt={imageAlt} class="w-full" />
+        <Image src={imageSrc} alt={imageAlt} class="w-full" sizes="100vw" />
       </div>
     )}
     {stats.length > 0 && (
@@ -83,7 +84,7 @@ const headingParts = heading.split(/(\*[^*]+\*)/g).filter(Boolean).map(part => {
         {stats.map((stat) => (
           <div class="rounded-lg bg-white/10 p-6 text-center">
             {stat.icon && (
-              <img src={stat.icon} alt="" class="mx-auto mb-3 h-8 w-8 opacity-70" />
+              <Image src={stat.icon} alt="" class="mx-auto mb-3 h-8 w-8 opacity-70" sizes="32px" />
             )}
             <p class="text-3xl font-extrabold text-accent">{stat.value}</p>
             <p class="mt-2 text-sm text-white/80">{stat.label}</p>

--- a/src/components/cta-card.astro
+++ b/src/components/cta-card.astro
@@ -1,5 +1,6 @@
 ---
 import { Button } from "@/components/ui/button";
+import Image from "@/components/image.astro";
 
 interface Props {
   /** Main heading text. Wrap words in *asterisks* for accent colour */
@@ -47,7 +48,7 @@ const hasAccentSyntax = headingParts.some(p => p.accent);
     >
       {imageSrc && (
         <div class="hidden lg:flex lg:justify-center">
-          <img src={imageSrc} alt={imageAlt} class="object-cover" />
+          <Image src={imageSrc} alt={imageAlt} class="object-cover" sizes="(min-width: 1024px) 50vw, 0px" />
         </div>
       )}
       <div>

--- a/src/components/feature-grid.astro
+++ b/src/components/feature-grid.astro
@@ -1,4 +1,6 @@
 ---
+import Image from "@/components/image.astro";
+
 interface Feature {
   icon?: string;
   title: string;
@@ -86,7 +88,7 @@ const headingParts = heading.split(/(\*[^*]+\*)/g).filter(Boolean).map(part => {
             ]}>
               <div class="flex flex-col items-start">
                 {feature.icon && (
-                  <img src={feature.icon} alt="" class="mb-3 h-12 w-12 md:mb-4" />
+                  <Image src={feature.icon} alt="" class="mb-3 h-12 w-12 md:mb-4" sizes="48px" />
                 )}
                 <h3 class="text-xl font-semibold text-primary">{feature.title}</h3>
                 <p class="mt-2">{feature.description}</p>
@@ -117,7 +119,7 @@ const headingParts = heading.split(/(\*[^*]+\*)/g).filter(Boolean).map(part => {
         <div class={`mt-12 grid gap-6 ${cardColumnClasses[columns]}`}>
           {features.map((feature) => (
             <div class="rounded-lg border bg-white p-5 shadow-sm">
-              {feature.icon && <img src={feature.icon} alt="" class="mb-4 h-10 w-10" />}
+              {feature.icon && <Image src={feature.icon} alt="" class="mb-4 h-10 w-10" sizes="40px" />}
               <h3 class="text-lg font-bold text-primary">{feature.title}</h3>
               <p class="mt-2 text-sm text-gray-darker">{feature.description}</p>
               {feature.linkText && (
@@ -155,7 +157,7 @@ const headingParts = heading.split(/(\*[^*]+\*)/g).filter(Boolean).map(part => {
             ]}>
               {feature.icon && (
                 <div class="mb-2 md:mb-3">
-                  <img src={feature.icon} alt="" class="h-8 w-auto" />
+                  <Image src={feature.icon} alt="" class="h-8 w-auto" sizes="32px" />
                 </div>
               )}
               <h3 class="mb-2 text-lg font-semibold text-primary lg:text-xl">{feature.title}</h3>

--- a/src/components/hero.astro
+++ b/src/components/hero.astro
@@ -1,5 +1,6 @@
 ---
 import { Button } from "@/components/ui/button";
+import Image from "@/components/image.astro";
 
 interface CTA {
   text: string;
@@ -106,10 +107,12 @@ const {
         )}
       </div>
       <div class="flex items-center justify-center">
-        <img
+        <Image
           src={imageSrc}
           alt={imageAlt}
           class="shrink-0 object-cover w-full max-w-md"
+          loading="eager"
+          sizes="(min-width: 1024px) 50vw, 100vw"
         />
       </div>
     </div>

--- a/src/components/image.astro
+++ b/src/components/image.astro
@@ -1,0 +1,74 @@
+---
+/**
+ * Optimised image component.
+ *
+ * - SVGs and non-raster files: rendered as a plain <img> (no transformation needed).
+ * - Raster images (JPG, PNG, etc.): rendered as a <picture> with AVIF + WebP
+ *   <source> elements backed by the Netlify Image CDN, with a JPEG <img> fallback.
+ *
+ * In local dev the Netlify CDN isn't available, so raster images also fall back
+ * to a plain <img> with the original src.
+ */
+import { isRaster, makeSrcset, netlifyUrl } from "@/lib/netlify-image";
+
+interface Props {
+  src: string;
+  alt: string;
+  class?: string;
+  width?: number;
+  height?: number;
+  /** Defaults to "lazy". Use "eager" for above-the-fold images. */
+  loading?: "lazy" | "eager";
+  /** Passed to <source> and <img> to help the browser pick the right srcset entry. */
+  sizes?: string;
+  /** Override the default responsive widths [400, 800, 1200, 1600]. */
+  widths?: number[];
+}
+
+const {
+  src,
+  alt,
+  class: className,
+  width,
+  height,
+  loading = "lazy",
+  sizes = "100vw",
+  widths,
+} = Astro.props;
+
+const useNetlify = isRaster(src) && !import.meta.env.DEV;
+---
+
+{useNetlify ? (
+  <picture>
+    <source
+      type="image/avif"
+      srcset={makeSrcset(src, "avif", widths)}
+      sizes={sizes}
+    />
+    <source
+      type="image/webp"
+      srcset={makeSrcset(src, "webp", widths)}
+      sizes={sizes}
+    />
+    <img
+      src={netlifyUrl(src, width ?? 1200, "jpeg")}
+      alt={alt}
+      class={className}
+      width={width}
+      height={height}
+      loading={loading}
+      decoding="async"
+    />
+  </picture>
+) : (
+  <img
+    src={src}
+    alt={alt}
+    class={className}
+    width={width}
+    height={height}
+    loading={loading}
+    decoding="async"
+  />
+)}

--- a/src/components/logo-marquee.astro
+++ b/src/components/logo-marquee.astro
@@ -1,4 +1,6 @@
 ---
+import Image from "@/components/image.astro";
+
 interface Logo {
   name: string;
   logo: string;
@@ -55,11 +57,11 @@ const fadeFrom = fadeBgClass || (bgClass.includes("accent-lightest-2") ? "from-a
                 greyscale && "grayscale opacity-60 transition-all duration-300 hover:grayscale-0 hover:opacity-100",
               ]}
             >
-              <img
+              <Image
                 class="max-h-full max-w-full object-contain"
                 src={logo.logo}
                 alt={logo.name}
-                loading="lazy"
+                sizes="160px"
               />
             </a>
           ))}

--- a/src/components/react/article-carousel.tsx
+++ b/src/components/react/article-carousel.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import useEmblaCarousel from "embla-carousel-react";
 import { Button } from "@/components/ui/button";
 import { ArrowLeft, ArrowRight } from "lucide-react";
+import { Img } from "@/components/react/image";
 
 export interface ArticleOrg {
   /** Organisation name (shown as fallback if no logo) */
@@ -75,10 +76,11 @@ export function ArticleCarousel({ heading, body, articles, showOrganizations = t
                 <div className="h-full rounded-xl border bg-white shadow-sm flex flex-col overflow-hidden">
                   {article.imageSrc && (
                     <div className="aspect-[16/9] overflow-hidden bg-gray-light">
-                      <img
+                      <Img
                         src={article.imageSrc}
                         alt={article.title}
                         className="h-full w-full object-cover"
+                        sizes="(min-width: 1024px) 33vw, (min-width: 640px) 50vw, 100vw"
                       />
                     </div>
                   )}
@@ -89,10 +91,11 @@ export function ArticleCarousel({ heading, body, articles, showOrganizations = t
                           {article.organizations.map((org, i) => (
                             <React.Fragment key={i}>
                               {org.logoSrc ? (
-                                <img
+                                <Img
                                   src={org.logoSrc}
                                   alt={org.name}
                                   className="h-4 max-w-[60px] w-auto object-contain"
+                                  sizes="60px"
                                 />
                               ) : (
                                 <span className="text-xs font-semibold text-primary">

--- a/src/components/react/image.tsx
+++ b/src/components/react/image.tsx
@@ -1,0 +1,70 @@
+/**
+ * Optimised image component for React islands.
+ *
+ * Mirrors the logic of src/components/image.astro — SVGs pass through as plain
+ * <img> elements; raster images get a <picture> with AVIF + WebP sources backed
+ * by the Netlify Image CDN. Falls back to a plain <img> in local dev.
+ */
+import { isRaster, makeSrcset, netlifyUrl } from "@/lib/netlify-image";
+
+interface ImgProps {
+  src: string;
+  alt: string;
+  className?: string;
+  width?: number;
+  height?: number;
+  loading?: "lazy" | "eager";
+  sizes?: string;
+  widths?: number[];
+}
+
+export function Img({
+  src,
+  alt,
+  className,
+  width,
+  height,
+  loading = "lazy",
+  sizes = "100vw",
+  widths,
+}: ImgProps) {
+  const useNetlify = isRaster(src) && !import.meta.env.DEV;
+
+  if (!useNetlify) {
+    return (
+      <img
+        src={src}
+        alt={alt}
+        className={className}
+        width={width}
+        height={height}
+        loading={loading}
+        decoding="async"
+      />
+    );
+  }
+
+  return (
+    <picture>
+      <source
+        type="image/avif"
+        srcSet={makeSrcset(src, "avif", widths)}
+        sizes={sizes}
+      />
+      <source
+        type="image/webp"
+        srcSet={makeSrcset(src, "webp", widths)}
+        sizes={sizes}
+      />
+      <img
+        src={netlifyUrl(src, width ?? 1200, "jpeg")}
+        alt={alt}
+        className={className}
+        width={width}
+        height={height}
+        loading={loading}
+        decoding="async"
+      />
+    </picture>
+  );
+}

--- a/src/components/react/tabbed-section.tsx
+++ b/src/components/react/tabbed-section.tsx
@@ -2,6 +2,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { motion } from "framer-motion";
 import { useState } from "react";
 import { cn } from "@/lib/utils";
+import { Img } from "@/components/react/image";
 
 export type Tab = {
   value: string;
@@ -114,13 +115,13 @@ export const TabbedSection = (props: Props) => {
               className="flex items-center justify-end data-[state=active]:animate-tabs"
             >
               {tab.image && (
-                <img src={tab.image.src} alt={tab.image.alt ?? ""} className="size-full object-cover" />
+                <Img src={tab.image.src} alt={tab.image.alt ?? ""} className="size-full object-cover" sizes="(min-width: 1024px) 50vw, 100vw" />
               )}
             </TabsContent>
           ))
         ) : (
           imageSrc && (
-            <img src={imageSrc} alt={imageAlt} className="size-full object-cover" />
+            <Img src={imageSrc} alt={imageAlt} className="size-full object-cover" sizes="(min-width: 1024px) 50vw, 100vw" />
           )
         )}
       </div>

--- a/src/components/resource-cards.astro
+++ b/src/components/resource-cards.astro
@@ -1,5 +1,6 @@
 ---
 import { Button } from "@/components/ui/button";
+import Image from "@/components/image.astro";
 
 interface ResourceCard {
   /** Card icon image path */
@@ -70,7 +71,7 @@ const headingParts = heading.split(/(\*[^*]+\*)/g).filter(Boolean).map(part => {
         <div class="flex flex-col items-center text-center p-6 rounded-xl border bg-white shadow-sm hover:shadow-md transition-shadow">
           {card.icon && (
             <div class="mb-4">
-              <img src={card.icon} alt="" class="h-12 w-12" />
+              <Image src={card.icon} alt="" class="h-12 w-12" sizes="48px" />
             </div>
           )}
           <h3 class="text-xl font-bold mb-2">{card.title}</h3>

--- a/src/components/team-grid.astro
+++ b/src/components/team-grid.astro
@@ -2,6 +2,7 @@
 import { Card } from "@/components/ui/card";
 import LinkedInIcon from "@/assets/linkedin-icon.svg";
 import peopleData from "@/data/people.json";
+import Image from "@/components/image.astro";
 
 interface TeamMember {
   fullName: string;
@@ -105,7 +106,7 @@ const colClasses: Record<number, string> = {
             <Card className="flex flex-col items-center p-8 text-center bg-primary-darker border-0">
               <div class="mb-4 flex size-28 items-center justify-center overflow-hidden rounded-full bg-primary-light/30">
                 {member.photo ? (
-                  <img src={member.photo} alt={member.fullName} class="size-full object-cover" />
+                  <Image src={member.photo} alt={member.fullName} class="size-full object-cover" sizes="112px" />
                 ) : (
                   <span class="text-3xl font-bold text-white/60">
                     {member.fullName.split(" ").map(n => n[0]).join("")}
@@ -154,7 +155,7 @@ const colClasses: Record<number, string> = {
             <Card className="flex flex-col items-center p-6 text-center h-full justify-between w-full max-w-xs mx-auto">
               <div class="mb-4 flex size-20 items-center justify-center overflow-hidden rounded-full bg-primary-lightest-2">
                 {member.photo ? (
-                  <img src={member.photo} alt={member.fullName} class="size-full object-cover" />
+                  <Image src={member.photo} alt={member.fullName} class="size-full object-cover" sizes="80px" />
                 ) : (
                   <span class="text-xl font-bold text-primary/40">
                     {member.fullName.split(" ").map(n => n[0]).join("")}
@@ -192,6 +193,6 @@ const colClasses: Record<number, string> = {
     )}
   </div>
   {decorSrc && (
-    <img class="absolute -top-1/2 left-0 -z-10 hidden lg:block" src={decorSrc} />
+    <Image class="absolute -top-1/2 left-0 -z-10 hidden lg:block" src={decorSrc} alt="" />
   )}
 </section>

--- a/src/components/text-with-image.astro
+++ b/src/components/text-with-image.astro
@@ -1,5 +1,6 @@
 ---
 import { Button } from "@/components/ui/button";
+import Image from "@/components/image.astro";
 
 interface IconFeature {
   /** Path to icon SVG */
@@ -61,7 +62,7 @@ const {
   <div class="container grid items-center gap-10 md:grid-cols-2 md:gap-16">
     {reversed && (
       <div class="order-2 md:order-1 flex justify-center">
-        <img src={imageSrc} alt={imageAlt} class="w-full max-w-md" />
+        <Image src={imageSrc} alt={imageAlt} class="w-full max-w-md" sizes="(min-width: 768px) 50vw, 100vw" />
       </div>
     )}
     <div class={reversed ? "order-1 md:order-2" : ""}>
@@ -95,9 +96,9 @@ const {
           {iconFeatures.map((feature) => (
             <div class="flex items-start justify-start gap-3">
               <div class="relative flex w-16 shrink-0 items-center justify-center p-3">
-                <img src={feature.icon} alt="" class="relative h-8 w-8" />
+                <Image src={feature.icon} alt="" class="relative h-8 w-8" sizes="32px" />
                 {iconFeaturesBgIcon && (
-                  <img src={iconFeaturesBgIcon} alt="" class="absolute inset-0 size-full" />
+                  <Image src={iconFeaturesBgIcon} alt="" class="absolute inset-0 size-full" sizes="64px" />
                 )}
               </div>
               <p set:html={feature.description} />
@@ -115,7 +116,7 @@ const {
     </div>
     {!reversed && (
       <div class="flex justify-center">
-        <img src={imageSrc} alt={imageAlt} class="w-full max-w-md" />
+        <Image src={imageSrc} alt={imageAlt} class="w-full max-w-md" sizes="(min-width: 768px) 50vw, 100vw" />
       </div>
     )}
   </div>

--- a/src/lib/netlify-image.ts
+++ b/src/lib/netlify-image.ts
@@ -1,0 +1,34 @@
+/**
+ * Netlify Image CDN helpers.
+ *
+ * Netlify's image transformation service is available at /.netlify/images and
+ * works for any image served from the same Netlify site. In local dev the CDN
+ * isn't available, so we fall back to the original URL.
+ */
+
+const DEFAULT_WIDTHS = [400, 800, 1200, 1600];
+
+/** Returns true for raster image paths that the Netlify CDN can transform. */
+export function isRaster(src: string): boolean {
+  return /\.(jpe?g|png|gif|webp|avif)(\?.*)?$/i.test(src);
+}
+
+/** Build a single Netlify Image CDN URL for the given width and format. */
+export function netlifyUrl(
+  src: string,
+  width: number,
+  format: "avif" | "webp" | "jpeg",
+): string {
+  if (import.meta.env.DEV) return src;
+  return `/.netlify/images?url=${encodeURIComponent(src)}&w=${width}&fm=${format}&q=80`;
+}
+
+/** Build a srcset string for the given format across all widths. */
+export function makeSrcset(
+  src: string,
+  format: "avif" | "webp" | "jpeg",
+  widths: number[] = DEFAULT_WIDTHS,
+): string {
+  if (import.meta.env.DEV) return "";
+  return widths.map((w) => `${netlifyUrl(src, w, format)} ${w}w`).join(", ");
+}


### PR DESCRIPTION
## Summary

- Adds Netlify Image CDN support across all parameterised components
- Raster images (JPG/PNG) now served as `<picture>` with AVIF + WebP sources via Netlify's image transformation service, with JPEG fallback
- SVGs pass through unchanged (already optimal)
- All images get correct `sizes` hints so browsers fetch the right resolution
- Hero image uses `loading="eager"`; all others lazy-load by default
- Falls back to original URLs in local dev (CDN not available locally)

## Files added
- `src/lib/netlify-image.ts` — URL builder utility
- `src/components/image.astro` — Astro image wrapper
- `src/components/react/image.tsx` — React island equivalent

## Components updated
hero, text-with-image, cta-card, card-grid, feature-grid, resource-cards, community-reach, team-grid, logo-marquee, article-carousel, tabbed-section

## Expected Lighthouse improvements
- Serve images in next-gen formats (AVIF/WebP)
- Properly sized images (responsive srcset with sizes hints)
- Lazy loading on below-fold images

🤖 Generated with [Claude Code](https://claude.com/claude-code)