### PR TITLE
Fix i18n: treat English as default language, remove /en/ prefix from …

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,12 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+/**
+ * Generate a URL path for an article, stripping the default language prefix (en/).
+ * Non-English articles keep their language prefix (e.g. /articles/ja/slug/).
+ */
+export function articleUrl(id: string): string {
+  const slug = id.startsWith("en/") ? id.slice(3) : id;
+  return `/articles/${slug}/`;
+}

--- a/src/pages/articles/[...page].astro
+++ b/src/pages/articles/[...page].astro
@@ -1,6 +1,7 @@
 ---
 import type { GetStaticPaths } from "astro";
 import { getCollection } from "astro:content";
+import { articleUrl } from "@/lib/utils";
 import { Image } from "astro:assets";
 import Layout from "@/layouts/showcase.astro";
 import Navbar from "@/components/navbar.astro";
@@ -71,7 +72,7 @@ const { page } = Astro.props;
           });
           return (
             <a
-              href={`/articles/${article.id}`}
+              href={articleUrl(article.id)}
               class="group rounded-xl border border-border bg-white shadow-sm flex flex-col overflow-hidden hover:shadow-md transition-shadow"
             >
               {article.data.mainImage && (

--- a/src/pages/articles/[...slug].astro
+++ b/src/pages/articles/[...slug].astro
@@ -11,7 +11,7 @@ import { navItems } from "@/lib/nav-items";
 export async function getStaticPaths() {
   const articles = await getCollection("articles");
   return articles.map((article) => ({
-    params: { slug: article.id },
+    params: { slug: article.id.startsWith("en/") ? article.id.slice(3) : article.id },
     props: { article },
   }));
 }
@@ -27,7 +27,7 @@ const formattedDate = new Date(article.data.date).toLocaleDateString("en-GB", {
 
 const seoDescription = article.data.description || article.data.summary || article.data.teaserText || "";
 const authorNames = article.data.authors?.map((a) => a.fullName) || [];
-const isEnglish = article.id.startsWith("en/");
+const isEnglish = article.data.lang === "en";
 ---
 
 <Layout

--- a/src/pages/community/index.astro
+++ b/src/pages/community/index.astro
@@ -1,5 +1,6 @@
 ---
 import { getCollection } from "astro:content";
+import { articleUrl } from "@/lib/utils";
 import Layout from "@/layouts/showcase.astro";
 import { navItems } from "@/lib/nav-items";
 
@@ -25,7 +26,7 @@ const communityArticles = allArticles
     title: a.data.title,
     description: a.data.summary || a.data.teaserText || "",
     imageSrc: a.data.mainImage?.src || undefined,
-    href: `/articles/${a.id}/`,
+    href: articleUrl(a.id),
     cta: "Read the article →",
   }));
 ---

--- a/src/pages/education/index.astro
+++ b/src/pages/education/index.astro
@@ -1,5 +1,6 @@
 ---
 import { getCollection } from "astro:content";
+import { articleUrl } from "@/lib/utils";
 import Layout from "@/layouts/showcase.astro";
 import { navItems } from "@/lib/nav-items";
 
@@ -27,7 +28,7 @@ const educationArticles = allArticles
     title: a.data.title,
     description: a.data.summary || a.data.teaserText || "",
     imageSrc: a.data.mainImage?.src || undefined,
-    href: `/articles/${a.id}/`,
+    href: articleUrl(a.id),
     cta: "Read the article →",
   }));
 ---

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,5 +1,6 @@
 ---
 import { getCollection } from "astro:content";
+import { articleUrl } from "@/lib/utils";
 import Layout from "@/layouts/showcase.astro";
 import { navItems } from "@/lib/nav-items";
 
@@ -36,7 +37,7 @@ const featuredArticles = allArticles
     title: a.data.title,
     description: a.data.summary || a.data.teaserText,
     imageSrc: a.data.mainImage?.src || "/assets/hero-illustration.svg",
-    href: `/articles/${a.id}/`,
+    href: articleUrl(a.id),
     cta: "Read the story →",
     organizations: (a.data.organizations || []).map((name: string) => ({
       name,

--- a/src/pages/policy/index.astro
+++ b/src/pages/policy/index.astro
@@ -13,6 +13,7 @@ import Footer from "@/components/footer.astro";
 
 import teamData from "@/data/people.json";
 import { getCollection } from "astro:content";
+import { articleUrl } from "@/lib/utils";
 
 // ----- Leadership photos from team.json -----
 const chrisAdams = teamData.find((p: any) => p.fullName === "Chris Adams");
@@ -31,7 +32,7 @@ const policyArticles = allArticles
     title: a.data.title,
     description: a.data.summary || a.data.teaserText || "",
     imageSrc: a.data.mainImage?.src || undefined,
-    href: `/articles/${a.id}/`,
+    href: articleUrl(a.id),
     cta: "Read the article",
   }));
 ---

--- a/src/pages/standards/sci-web/index.astro
+++ b/src/pages/standards/sci-web/index.astro
@@ -26,6 +26,7 @@ const parentWg = projects.find(p => p.name === sciWebProject?.parent);
 
 // Pull SCI for Web tagged articles for the carousel
 import { getCollection } from "astro:content";
+import { articleUrl } from "@/lib/utils";
 import membersData from "@/data/members.json";
 const logoMap = new Map((membersData as any[]).filter((m: any) => m.active && m.logo && !m.hideLogo).map((m: any) => [m.companyName.toLowerCase(), `/assets/${m.logo}`]));
 const allArticles = await getCollection("articles");
@@ -36,7 +37,7 @@ const carouselArticles = allArticles
     title: a.data.title,
     description: a.data.summary || a.data.teaserText || "",
     imageSrc: a.data.mainImage?.src || "/assets/hero-illustration.svg",
-    href: `/articles/${a.id}/`,
+    href: articleUrl(a.id),
     cta: "Read more →",
     organizations: (a.data.organizations || []).map((name: string) => ({
       name,

--- a/src/pages/stories/[slug].astro
+++ b/src/pages/stories/[slug].astro
@@ -1,5 +1,6 @@
 ---
 import { getCollection, render } from "astro:content";
+import { articleUrl } from "@/lib/utils";
 import Layout from "@/layouts/showcase.astro";
 import Navbar from "@/components/navbar.astro";
 import Footer from "@/components/footer.astro";
@@ -35,7 +36,7 @@ const relatedArticles = relatedSlugs
     title: a!.data.title,
     description: a!.data.teaserText || a!.data.summary || "",
     imageSrc: a!.data.mainImage?.src || "/assets/hero-illustration.svg",
-    href: `/articles/${a!.id}/`,
+    href: articleUrl(a!.id),
     cta: "Read the article →",
     organizations: (a!.data.organizations || []).map((name: string) => ({
       name,

--- a/src/pages/stories/_soft-framework.astro
+++ b/src/pages/stories/_soft-framework.astro
@@ -1,5 +1,6 @@
 ---
 import { getCollection } from "astro:content";
+import { articleUrl } from "@/lib/utils";
 import Layout from "@/layouts/showcase.astro";
 import Navbar from "@/components/navbar.astro";
 import Footer from "@/components/footer.astro";
@@ -28,7 +29,7 @@ const relatedArticles = relatedSlugs
     title: a!.data.title,
     description: a!.data.teaserText || a!.data.summary || "",
     imageSrc: a!.data.mainImage?.src || "/assets/hero-illustration.svg",
-    href: `/articles/${a!.id}/`,
+    href: articleUrl(a!.id),
     cta: "Read the article →",
     organizations: (a!.data.organizations || []).map((name: string) => ({
       name,

--- a/src/pages/stories/carbon-aware-sdk.astro
+++ b/src/pages/stories/carbon-aware-sdk.astro
@@ -1,5 +1,6 @@
 ---
 import { getCollection } from "astro:content";
+import { articleUrl } from "@/lib/utils";
 import Layout from "@/layouts/showcase.astro";
 import Navbar from "@/components/navbar.astro";
 import Footer from "@/components/footer.astro";
@@ -29,7 +30,7 @@ const relatedArticles = relatedSlugs
     title: a!.data.title,
     description: a!.data.teaserText || a!.data.summary || "",
     imageSrc: a!.data.mainImage?.src || "/assets/hero-illustration.svg",
-    href: `/articles/${a!.id}/`,
+    href: articleUrl(a!.id),
     cta: "Read the article →",
     organizations: (a!.data.organizations || []).map((name: string) => ({
       name,

--- a/src/pages/stories/sci-for-ai.astro
+++ b/src/pages/stories/sci-for-ai.astro
@@ -1,5 +1,6 @@
 ---
 import { getCollection } from "astro:content";
+import { articleUrl } from "@/lib/utils";
 import Layout from "@/layouts/showcase.astro";
 import Navbar from "@/components/navbar.astro";
 import Footer from "@/components/footer.astro";
@@ -29,7 +30,7 @@ const relatedArticles = relatedSlugs
     title: a!.data.title,
     description: a!.data.teaserText || a!.data.summary || "",
     imageSrc: a!.data.mainImage?.src || "/assets/hero-illustration.svg",
-    href: `/articles/${a!.id}/`,
+    href: articleUrl(a!.id),
     cta: "Read the article →",
     organizations: (a!.data.organizations || []).map((name: string) => ({
       name,


### PR DESCRIPTION
…article URLs

English articles now render at /articles/slug/ instead of /articles/en/slug/. Non-English articles retain their language prefix (e.g. /articles/ja/slug/). Added articleUrl() utility to centralize URL generation logic.

https://claude.ai/code/session_0112pgEjBZkbKrKAjo17VhaL